### PR TITLE
[feat-26] 힌트 API 구현 및 응답/에러 처리 표준화

### DIFF
--- a/src/main/java/com/hufs/algoing/aisolved/controller/AISolvedController.java
+++ b/src/main/java/com/hufs/algoing/aisolved/controller/AISolvedController.java
@@ -1,6 +1,7 @@
 package com.hufs.algoing.aisolved.controller;
 
 import com.hufs.algoing.global.chatgpt.service.GPTService;
+import com.hufs.algoing.global.code.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -11,15 +12,16 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "AISolved API", description = "OpenAI 이용 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/ai")
+@RequestMapping("/api/ai")
 public class AISolvedController {
 
     private final GPTService gptService;
 
     @Operation(summary = "모든 문제 분석 요청", description = "DB에 있는 모든 문제를 OpenAI에게 분석 요청합니다.")
     @PostMapping
-    public void analyzeAll() {
+    public ApiResponse<String> analyzeAll() {
         gptService.analyzeAllProblems();
+        return ApiResponse.onSuccess("문제 분석을 요청했습니다");
     }
 
 

--- a/src/main/java/com/hufs/algoing/aisolved/entity/AISolved.java
+++ b/src/main/java/com/hufs/algoing/aisolved/entity/AISolved.java
@@ -1,11 +1,15 @@
 package com.hufs.algoing.aisolved.entity;
 
+import com.hufs.algoing.hint.entity.Hint;
 import com.hufs.algoing.problem.entity.Problem;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -47,6 +51,9 @@ public class AISolved {
     @JoinColumn(name="problem_id")
     private Problem problem;
 
+    @OneToMany(mappedBy = "aiSolved", cascade = CascadeType.ALL)
+    private List<Hint> hints = new ArrayList<>();
+
     @Override
     public String toString() {
         return "AISolved{" +
@@ -61,5 +68,14 @@ public class AISolved {
                 ", problem=" + (problem != null ? problem.getProblemId() : null) +  // 문제 ID만 출력 (문제 객체가 null일 수 있기 때문)
                 '}';
     }
+
+    public void addHint(Hint hint) {
+        if (this.hints == null) {
+            this.hints = new ArrayList<>();
+        }
+        this.hints.add(hint);
+        hint.updateAISolved(this);
+    }
+
 
 }

--- a/src/main/java/com/hufs/algoing/global/chatgpt/service/GPTService.java
+++ b/src/main/java/com/hufs/algoing/global/chatgpt/service/GPTService.java
@@ -4,7 +4,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hufs.algoing.aisolved.entity.AISolved;
 import com.hufs.algoing.aisolved.repository.AISolvedRepository;
-import com.hufs.algoing.global.exception.BadWebClientRequestException;
+import com.hufs.algoing.global.exception.custom.BadWebClientRequestException;
+import com.hufs.algoing.hint.entity.Hint;
 import com.hufs.algoing.problem.entity.Problem;
 import com.hufs.algoing.problem.repository.ProblemRepository;
 import com.hufs.algoing.review.dto.ReviewRequestDTO;
@@ -15,7 +16,6 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
-import org.springframework.beans.factory.annotation.Value;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.http.MediaType;
@@ -136,7 +135,21 @@ public class GPTService {
                                 .problem(problem)
                                 .build();
 
+                        for(int i=1;i<=3; i++){
+                            String key ="hint"+i;
+                            String value = parsed.get(key).asText();
+
+                            Hint hint = Hint.builder()
+                                    .content(value)
+                                    .order(i)
+                                    .build();
+
+                            aiSolved.addHint(hint);
+                            hint.updateAISolved(aiSolved);
+                        }
+
                         aiSolvedRepository.save(aiSolved);
+
                     } catch (Exception e) {
                         log.error("Exception [Err_Location] : {}", e.getStackTrace()[0]);
                     }
@@ -203,7 +216,7 @@ public class GPTService {
     // 리뷰 - 가독성 요청
     public Mono<JsonNode> requestReadbility(ReviewRequestDTO dto){
 
-        log.info("가독성 리뷰 - 유저: {}, Thread: {}", dto.getUserId(), Thread.currentThread().getName());
+        log.info("가독성 리뷰 - Thread: {}", Thread.currentThread().getName());
 
         ObjectNode requestBody = objectMapper.createObjectNode();
         requestBody.put("model", "gpt-4o-mini");
@@ -264,7 +277,7 @@ public class GPTService {
     // 리뷰 - 최적성 요청
     public Mono<JsonNode> requestOptimization(ReviewRequestDTO dto){
 
-        log.info("최적성 리뷰 - 유저: {}, Thread: {}", dto.getUserId(), Thread.currentThread().getName());
+        log.info("최적성 리뷰 - Thread: {}", Thread.currentThread().getName());
 
         ObjectNode requestBody = objectMapper.createObjectNode();
         requestBody.put("model", "gpt-4o-mini");
@@ -325,7 +338,7 @@ public class GPTService {
     // 리뷰 - 중복성 요청
     public Mono<JsonNode> requestDuplicate(ReviewRequestDTO dto){
 
-        log.info("최적성 리뷰 - 유저: {}, Thread: {}", dto.getUserId(), Thread.currentThread().getName());
+        log.info("최적성 리뷰 - Thread: {}", Thread.currentThread().getName());
 
         ObjectNode requestBody = objectMapper.createObjectNode();
         requestBody.put("model", "gpt-4o-mini");

--- a/src/main/java/com/hufs/algoing/global/code/ApiResponse.java
+++ b/src/main/java/com/hufs/algoing/global/code/ApiResponse.java
@@ -1,0 +1,37 @@
+package com.hufs.algoing.global.code;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;
+
+
+    //성공한 경우 응답 생성
+
+    public static <T> ApiResponse<T> onSuccess(T result){
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
+    }
+
+    public static <T> ApiResponse<T> of(BaseCode code, T result){
+        return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
+    }
+
+
+    // 실패한 경우 응답 생성
+    public static <T> ApiResponse<T> onFailure(String code, String message, T data){
+        return new ApiResponse<>(false, code, message, data);
+    }
+}

--- a/src/main/java/com/hufs/algoing/global/code/BaseCode.java
+++ b/src/main/java/com/hufs/algoing/global/code/BaseCode.java
@@ -1,0 +1,8 @@
+package com.hufs.algoing.global.code;
+
+public interface BaseCode {
+
+    ReasonDTO getReason();
+
+    ReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/com/hufs/algoing/global/code/BaseErrorCode.java
+++ b/src/main/java/com/hufs/algoing/global/code/BaseErrorCode.java
@@ -1,0 +1,8 @@
+package com.hufs.algoing.global.code;
+
+public interface BaseErrorCode {
+
+    ErrorReasonDTO getReason();
+
+    ErrorReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/com/hufs/algoing/global/code/ErrorReasonDTO.java
+++ b/src/main/java/com/hufs/algoing/global/code/ErrorReasonDTO.java
@@ -1,0 +1,18 @@
+package com.hufs.algoing.global.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ErrorReasonDTO {
+
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess(){return isSuccess;}
+}

--- a/src/main/java/com/hufs/algoing/global/code/ErrorStatus.java
+++ b/src/main/java/com/hufs/algoing/global/code/ErrorStatus.java
@@ -1,0 +1,38 @@
+package com.hufs.algoing.global.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode{
+
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "사용자가 없습니다."),
+    HINT_NOT_FOUND(HttpStatus.BAD_REQUEST,"HINT4001","힌트가 없습니다."),
+    SNAPSHOT_NOT_FOUND(HttpStatus.BAD_REQUEST,"SNAPSHOT4001","해당 유저의 스냅샷이 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/hufs/algoing/global/code/ReasonDTO.java
+++ b/src/main/java/com/hufs/algoing/global/code/ReasonDTO.java
@@ -1,0 +1,18 @@
+package com.hufs.algoing.global.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ReasonDTO {
+
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess(){return isSuccess;}
+}

--- a/src/main/java/com/hufs/algoing/global/code/SuccessStatus.java
+++ b/src/main/java/com/hufs/algoing/global/code/SuccessStatus.java
@@ -1,0 +1,37 @@
+package com.hufs.algoing.global.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+
+    // 일반적인 응답
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .httpStatus(httpStatus)
+                .build()
+                ;
+    }
+}

--- a/src/main/java/com/hufs/algoing/global/exception/ExceptionAdvice.java
+++ b/src/main/java/com/hufs/algoing/global/exception/ExceptionAdvice.java
@@ -1,0 +1,60 @@
+package com.hufs.algoing.global.exception;
+
+import com.hufs.algoing.global.code.ApiResponse;
+import com.hufs.algoing.global.code.ErrorReasonDTO;
+import com.hufs.algoing.global.code.ErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        e.printStackTrace();
+        return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY, ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(), request, e.getMessage());
+    }
+
+    @ExceptionHandler(value = GeneralException.class)
+    public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
+        ErrorReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        return handleExceptionInternal(generalException, errorReasonHttpStatus, null, request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorReasonDTO reason,
+                                                           HttpHeaders headers, HttpServletRequest request) {
+        ApiResponse<Object> body = ApiResponse.onFailure(reason.getCode(), reason.getMessage(), null);
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                reason.getHttpStatus(),
+                webRequest
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
+                                                                HttpHeaders headers, HttpStatus status, WebRequest request, String errorPoint) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), errorPoint);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                status,
+                request
+        );
+    }
+}

--- a/src/main/java/com/hufs/algoing/global/exception/GeneralException.java
+++ b/src/main/java/com/hufs/algoing/global/exception/GeneralException.java
@@ -1,0 +1,21 @@
+package com.hufs.algoing.global.exception;
+
+import com.hufs.algoing.global.code.BaseErrorCode;
+import com.hufs.algoing.global.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+
+    private BaseErrorCode code;
+
+    public ErrorReasonDTO getErrorReason() {
+        return this.code.getReason();
+    }
+
+    public ErrorReasonDTO getErrorReasonHttpStatus(){
+        return this.code.getReasonHttpStatus();
+    }
+}

--- a/src/main/java/com/hufs/algoing/global/exception/SnapShotNotFoundException.java
+++ b/src/main/java/com/hufs/algoing/global/exception/SnapShotNotFoundException.java
@@ -1,7 +1,0 @@
-package com.hufs.algoing.global.exception;
-
-public class SnapShotNotFoundException extends RuntimeException {
-    public SnapShotNotFoundException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/hufs/algoing/global/exception/UserNotFoundException.java
+++ b/src/main/java/com/hufs/algoing/global/exception/UserNotFoundException.java
@@ -1,7 +1,0 @@
-package com.hufs.algoing.global.exception;
-
-public class UserNotFoundException extends RuntimeException {
-    public UserNotFoundException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/hufs/algoing/global/exception/custom/BadWebClientRequestException.java
+++ b/src/main/java/com/hufs/algoing/global/exception/custom/BadWebClientRequestException.java
@@ -1,4 +1,4 @@
-package com.hufs.algoing.global.exception;
+package com.hufs.algoing.global.exception.custom;
 
 import lombok.Getter;
 

--- a/src/main/java/com/hufs/algoing/global/exception/custom/HintNotFoundException.java
+++ b/src/main/java/com/hufs/algoing/global/exception/custom/HintNotFoundException.java
@@ -1,0 +1,9 @@
+package com.hufs.algoing.global.exception.custom;
+
+import com.hufs.algoing.global.code.BaseErrorCode;
+import com.hufs.algoing.global.exception.GeneralException;
+
+public class HintNotFoundException extends GeneralException {
+    public HintNotFoundException(BaseErrorCode errorCode) {super(errorCode);;
+    }
+}

--- a/src/main/java/com/hufs/algoing/global/exception/custom/SnapShotNotFoundException.java
+++ b/src/main/java/com/hufs/algoing/global/exception/custom/SnapShotNotFoundException.java
@@ -1,0 +1,10 @@
+package com.hufs.algoing.global.exception.custom;
+
+import com.hufs.algoing.global.code.BaseErrorCode;
+import com.hufs.algoing.global.exception.GeneralException;
+
+public class SnapShotNotFoundException extends GeneralException {
+    public SnapShotNotFoundException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/hufs/algoing/global/exception/custom/UserNotFoundException.java
+++ b/src/main/java/com/hufs/algoing/global/exception/custom/UserNotFoundException.java
@@ -1,0 +1,10 @@
+package com.hufs.algoing.global.exception.custom;
+
+import com.hufs.algoing.global.code.BaseErrorCode;
+import com.hufs.algoing.global.exception.GeneralException;
+
+public class UserNotFoundException extends GeneralException {
+    public UserNotFoundException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/hufs/algoing/hint/controller/HintController.java
+++ b/src/main/java/com/hufs/algoing/hint/controller/HintController.java
@@ -1,0 +1,35 @@
+package com.hufs.algoing.hint.controller;
+
+import com.hufs.algoing.global.code.ApiResponse;
+import com.hufs.algoing.hint.dto.HintResponseDTO;
+import com.hufs.algoing.hint.entity.Hint;
+import com.hufs.algoing.hint.service.HintService;
+import com.hufs.algoing.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Tag(name = "힌트 API", description = "힌트 요청 API")
+@RequestMapping("/api/problems/{problemId}/hints")
+@RequiredArgsConstructor
+public class HintController {
+
+    private final HintService hintService;
+    @GetMapping("/{hintOrder}")
+    @Operation(summary = "힌트 요청 API", description = "특정 문제 번호의 특정 순서 힌트를 가져옵니다.")
+    @Parameter(name = "problemId", description = "요청 힌트 문제 번호")
+    @Parameter(name = "hintOrder", description = "요청 힌트 순서")
+    public ApiResponse<HintResponseDTO> getHint(@PathVariable Long problemId, @PathVariable int hintOrder, @AuthenticationPrincipal User user) {
+        Hint hint = hintService.getHint(problemId, hintOrder);
+        hintService.minusPoint(user);
+        return ApiResponse.onSuccess(HintResponseDTO.fromEntity(hint.getContent(),hint.getOrder()));
+    }
+
+}

--- a/src/main/java/com/hufs/algoing/hint/dto/HintResponseDTO.java
+++ b/src/main/java/com/hufs/algoing/hint/dto/HintResponseDTO.java
@@ -1,0 +1,20 @@
+package com.hufs.algoing.hint.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "힌트 응답 DTO")
+public class HintResponseDTO {
+
+    @Schema(description = "힌트 내용")
+    private String content;
+    @Schema(description = "요청 힌트 순서")
+    private int order;
+
+    public static HintResponseDTO fromEntity(String content, int order) {
+        return HintResponseDTO.builder().content(content).order(order).build();
+    }
+}

--- a/src/main/java/com/hufs/algoing/hint/entity/Hint.java
+++ b/src/main/java/com/hufs/algoing/hint/entity/Hint.java
@@ -1,0 +1,34 @@
+package com.hufs.algoing.hint.entity;
+
+import com.hufs.algoing.aisolved.entity.AISolved;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Hint {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name="content")
+    private String content;
+
+    @Column(name="order")
+    private int order;
+
+    @ManyToOne
+    @JoinColumn(name="aiSolved_id" )
+    private AISolved aiSolved;
+
+    public void updateAISolved(AISolved solved) {
+        this.aiSolved = solved;
+    }
+}

--- a/src/main/java/com/hufs/algoing/hint/repository/HintRepository.java
+++ b/src/main/java/com/hufs/algoing/hint/repository/HintRepository.java
@@ -1,0 +1,12 @@
+package com.hufs.algoing.hint.repository;
+
+import com.hufs.algoing.hint.entity.Hint;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface HintRepository extends JpaRepository<Hint, Long> {
+    Optional<Hint> findHintByAiSolved_Problem_ProblemIdAndOrder(Long problemId, int order);
+}

--- a/src/main/java/com/hufs/algoing/hint/service/HintService.java
+++ b/src/main/java/com/hufs/algoing/hint/service/HintService.java
@@ -1,0 +1,34 @@
+package com.hufs.algoing.hint.service;
+
+import com.hufs.algoing.global.code.ErrorStatus;
+import com.hufs.algoing.global.exception.custom.HintNotFoundException;
+import com.hufs.algoing.hint.entity.Hint;
+import com.hufs.algoing.hint.repository.HintRepository;
+import com.hufs.algoing.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class HintService {
+
+    private final HintRepository hintRepository;
+
+    public Hint getHint(Long problemId, int order){
+
+        Hint hint = hintRepository
+                .findHintByAiSolved_Problem_ProblemIdAndOrder(problemId, order)
+                .orElseThrow(() -> new HintNotFoundException(ErrorStatus.HINT_NOT_FOUND));
+        return hint;
+    }
+
+    public void minusPoint(User user){
+        log.info("userId : {}, point: {}", user.getUserId(), user.getUserPoint());
+        int point = user.getUserPoint() - 3;
+        user.updatePoint(point);
+        log.info("update user point : {}", user.getUserPoint());
+    }
+}

--- a/src/main/java/com/hufs/algoing/problem/controller/ProblemController.java
+++ b/src/main/java/com/hufs/algoing/problem/controller/ProblemController.java
@@ -1,5 +1,6 @@
 package com.hufs.algoing.problem.controller;
 
+import com.hufs.algoing.global.code.ApiResponse;
 import com.hufs.algoing.problem.entity.Problem;
 import com.hufs.algoing.problem.service.ProblemCrawlService;
 import com.hufs.algoing.problem.service.ProblemService;
@@ -10,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/problems/")
+@RequestMapping("/api/problems/")
 public class ProblemController {
 
     @Autowired
@@ -18,8 +19,8 @@ public class ProblemController {
 
 
     @GetMapping("/{problemId}")
-    public Problem getProblemId(@PathVariable Long problemId){
-        return problemService.getOrCrawlProblem(problemId);
+    public ApiResponse<Problem> getProblemId(@PathVariable Long problemId){
+        return ApiResponse.onSuccess(problemService.getOrCrawlProblem(problemId));
     }
 
 

--- a/src/main/java/com/hufs/algoing/recommendation/controller/DailyRecommendController.java
+++ b/src/main/java/com/hufs/algoing/recommendation/controller/DailyRecommendController.java
@@ -1,5 +1,6 @@
 package com.hufs.algoing.recommendation.controller;
 
+import com.hufs.algoing.global.code.ApiResponse;
 import com.hufs.algoing.recommendation.dto.DailyRecommendDTO;
 import com.hufs.algoing.recommendation.service.DailyRecommendService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,7 +13,7 @@ import java.util.List;
 
 @Tag(name = "데일리 문제 추천 API", description = "데일리 문제 추천 API")
 @RestController
-@RequestMapping("/dailyRecommendations")
+@RequestMapping("/api/dailyRecommendations")
 @RequiredArgsConstructor
 public class DailyRecommendController {
 
@@ -22,11 +23,11 @@ public class DailyRecommendController {
     @Operation(summary = "userId", description = "요청 받은 사용자의 티어와 선호 문제 유형을 기반으로 문제를 추천합니다.")
     @Parameter(name = "long", description = "추천 받을 사용자 id")
     @GetMapping("/{userId}")
-    public List<DailyRecommendDTO> getDailyRecommendations(@PathVariable Long userId) {
+    public ApiResponse<List<DailyRecommendDTO>> getDailyRecommendations(@PathVariable Long userId) {
         // 서비스 호출하여 추천 문제 목록 가져오기
         List<DailyRecommendDTO> recommendations = dailyRecommendService.getDailyRecommendations(userId);
         recommendations.forEach(recommendation -> System.out.println(recommendation.toString()));
 
-        return recommendations;
+        return ApiResponse.onSuccess(recommendations);
     }
 }

--- a/src/main/java/com/hufs/algoing/recommendation/controller/WeaknessRecommendController.java
+++ b/src/main/java/com/hufs/algoing/recommendation/controller/WeaknessRecommendController.java
@@ -1,5 +1,6 @@
 package com.hufs.algoing.recommendation.controller;
 
+import com.hufs.algoing.global.code.ApiResponse;
 import com.hufs.algoing.recommendation.service.WeaknessRecommendService;
 import com.hufs.algoing.recommendation.dto.WeaknessRecommendDTO;
 
@@ -13,7 +14,7 @@ import java.util.List;
 
 @Tag(name = "약점 기반 문제 추천 API", description = "약점 기반 문제 추천 API")
 @RestController
-@RequestMapping("/weaknessRecommendations")
+@RequestMapping("/api/weaknessRecommendations")
 @RequiredArgsConstructor
 
 public class WeaknessRecommendController {
@@ -23,10 +24,10 @@ public class WeaknessRecommendController {
     @Operation(summary = "userId", description = "요청 받은 사용자의 약점을 기반으로 문제를 추천합니다.")
     @Parameter(name = "long", description = "추천 받을 사용자 id")
     @GetMapping("/{userId}")
-    public List<WeaknessRecommendDTO> getWeaknessRecommendations(@PathVariable Long userId){
+    public ApiResponse<List<WeaknessRecommendDTO>> getWeaknessRecommendations(@PathVariable Long userId){
         List<WeaknessRecommendDTO> recommendations = weaknessRecommendService.getWeaknessRecommendations(userId);
         recommendations.forEach(recommendation -> System.out.println(recommendation));
-        return recommendations;
+        return ApiResponse.onSuccess(recommendations);
     }
 
 }

--- a/src/main/java/com/hufs/algoing/recommendation/service/DailyRecommendService.java
+++ b/src/main/java/com/hufs/algoing/recommendation/service/DailyRecommendService.java
@@ -1,5 +1,7 @@
 package com.hufs.algoing.recommendation.service;
 
+import com.hufs.algoing.global.code.ErrorStatus;
+import com.hufs.algoing.global.exception.custom.UserNotFoundException;
 import com.hufs.algoing.problem.entity.Problem;
 import com.hufs.algoing.problem.entity.SubmittedProblem;
 import com.hufs.algoing.problem.repository.ProblemRepository;
@@ -26,7 +28,7 @@ public class DailyRecommendService {
 
         // 유저 정보 가져오기
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("유저 정보를 찾을 수 없습니다: " + userId));
+                .orElseThrow(() -> new UserNotFoundException(ErrorStatus.USER_NOT_FOUND));
 
         // 유저가 푼 문제 가져오기
         List<SubmittedProblem> solvedProblems = submittedProblemRepository.findByUserId(user);

--- a/src/main/java/com/hufs/algoing/recommendation/service/WeaknessRecommendService.java
+++ b/src/main/java/com/hufs/algoing/recommendation/service/WeaknessRecommendService.java
@@ -2,6 +2,8 @@ package com.hufs.algoing.recommendation.service;
 
 import com.hufs.algoing.aisolved.entity.AISolved;
 import com.hufs.algoing.aisolved.repository.AISolvedRepository;
+import com.hufs.algoing.global.code.ErrorStatus;
+import com.hufs.algoing.global.exception.custom.UserNotFoundException;
 import com.hufs.algoing.problem.entity.Problem;
 import com.hufs.algoing.problem.entity.SubmittedProblem;
 import com.hufs.algoing.problem.repository.ProblemRepository;
@@ -31,9 +33,9 @@ public class WeaknessRecommendService {
 
     public List<WeaknessRecommendDTO> getWeaknessRecommendations(Long userId) {
 
-        //유저가 받은 리뷰 가져오기
+        // 유저 정보 가져오기
         User user=userRepository.findById(userId)
-                .orElseThrow(()-> new IllegalArgumentException("유저가 받은 리뷰가 없습니다"+userId));
+                .orElseThrow(()-> new UserNotFoundException(ErrorStatus.USER_NOT_FOUND));
         System.out.println(user);
         //전체 문제 가져오기
         List<Problem> allProblems = problemRepository.findAll();

--- a/src/main/java/com/hufs/algoing/review/controller/ReviewController.java
+++ b/src/main/java/com/hufs/algoing/review/controller/ReviewController.java
@@ -1,18 +1,21 @@
 package com.hufs.algoing.review.controller;
 
+import com.hufs.algoing.global.code.ApiResponse;
 import com.hufs.algoing.review.dto.ReviewRequestDTO;
 import com.hufs.algoing.review.dto.ReviewResponseDTO;
 import com.hufs.algoing.review.entity.Review;
 import com.hufs.algoing.review.service.ReviewService;
+import com.hufs.algoing.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 
 @Tag(name = "Review API", description = "코드 리뷰 API")
-@RequestMapping("/reviews")
+@RequestMapping("/api/reviews")
 @RestController
 @RequiredArgsConstructor
 public class ReviewController {
@@ -20,9 +23,9 @@ public class ReviewController {
 
     @Operation(summary = "리뷰 요청 API", description = "해당 문제에 대한 AI 리뷰를 요청합니다.")
     @PostMapping
-    public Mono<ResponseEntity<ReviewResponseDTO>> requestReview(@RequestBody ReviewRequestDTO dto) {
-        return reviewService.handleReview(dto)
-                .map(reviewResponseDto -> ResponseEntity.ok(reviewResponseDto));
+    public Mono<ApiResponse<ReviewResponseDTO>> requestReview(@RequestBody ReviewRequestDTO dto, @AuthenticationPrincipal User user) {
+        return reviewService.handleReview(dto,user)
+                .map(reviewResponseDto -> ApiResponse.onSuccess(reviewResponseDto));
     }
 
 

--- a/src/main/java/com/hufs/algoing/review/dto/ReviewRequestDTO.java
+++ b/src/main/java/com/hufs/algoing/review/dto/ReviewRequestDTO.java
@@ -13,9 +13,6 @@ import lombok.Setter;
 @Schema(description = "리뷰 요청 DTO")
 public class ReviewRequestDTO {
 
-    @Schema(description = "리뷰 요청 유저 ID")
-    private Long userId;
-
     @Schema(description = "문제 번호")
     private Long problemNum;
 

--- a/src/main/java/com/hufs/algoing/review/service/ReviewService.java
+++ b/src/main/java/com/hufs/algoing/review/service/ReviewService.java
@@ -38,12 +38,12 @@ public class ReviewService {
     private final SnapShotService snapShotService;
 
     // 해당 문제의 가장 최신 리뷰
-    public ReviewResponseDTO getRecentReview(Long userId, Long problemNum) {
-        Review review = reviewRepository.getRecentReview(userId, problemNum);
+    public ReviewResponseDTO getRecentReview(User user, Long problemNum) {
+        Review review = reviewRepository.getRecentReview(user.getUserId(), problemNum);
         return new ReviewResponseDTO(review.getSummary());
     }
 
-    public Mono<ReviewResponseDTO> handleReview(ReviewRequestDTO dto) {
+    public Mono<ReviewResponseDTO> handleReview(ReviewRequestDTO dto, User user) {
 
         log.info(dto.toString());
         Mono<JsonNode> readReviewMono = handleReadReview(dto)
@@ -69,8 +69,6 @@ public class ReviewService {
                             .flatMap(summary -> {
 
                                 String finalSummary = summary.get("review").asText();
-
-                                User user = userRepository.findById(dto.getUserId()).orElseThrow(() -> new UsernameNotFoundException("유저를 찾을 수 없습니다. userId=" + dto.getUserId()));
 
                                 Review review = Review.builder()
                                         .code(dto.getCode())

--- a/src/main/java/com/hufs/algoing/snapshot/Service/SnapShotService.java
+++ b/src/main/java/com/hufs/algoing/snapshot/Service/SnapShotService.java
@@ -1,6 +1,7 @@
 package com.hufs.algoing.snapshot.Service;
 
-import com.hufs.algoing.global.exception.SnapShotNotFoundException;
+import com.hufs.algoing.global.code.ErrorStatus;
+import com.hufs.algoing.global.exception.custom.SnapShotNotFoundException;
 import com.hufs.algoing.review.entity.Review;
 import com.hufs.algoing.snapshot.dto.SnapShotDTO;
 import com.hufs.algoing.snapshot.entity.Snapshot;
@@ -23,7 +24,7 @@ public class SnapShotService {
 
         Snapshot snapshot = snapShotRepository
                 .getRecentSnapshot(userId)
-                .orElseThrow(() -> new SnapShotNotFoundException("해당 유저의 스냅샷이 없습니다. userId=" + userId));
+                .orElseThrow(() -> new SnapShotNotFoundException(ErrorStatus.SNAPSHOT_NOT_FOUND));
 
         return SnapShotDTO.fromEntity(snapshot);
     }

--- a/src/main/java/com/hufs/algoing/snapshot/controller/SnapShotController.java
+++ b/src/main/java/com/hufs/algoing/snapshot/controller/SnapShotController.java
@@ -1,14 +1,17 @@
 package com.hufs.algoing.snapshot.controller;
 
+import com.hufs.algoing.global.code.ApiResponse;
 import com.hufs.algoing.snapshot.Service.SnapShotService;
 import com.hufs.algoing.snapshot.dto.SnapShotDTO;
 
+import com.hufs.algoing.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,15 +20,14 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "SanpShot API", description = "유저의 스냅샷 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/snapshots")
+@RequestMapping("/api/snapshots")
 public class SnapShotController {
     private final SnapShotService snapShotService;
 
     @Operation(summary = "유저 가장 최신 스냅샷 조회", description = "해당 유저 ID를 기반으로 스냅샷 조회합니다.")
-    @Parameter(name = "userId", description = "스냅샷을 조회할 유저 ID")
-    @GetMapping("/{userId}")
-    public ResponseEntity<SnapShotDTO> snapShot(@PathVariable Long userId){
-        SnapShotDTO snapShotDTO = snapShotService.getRecentSnapShot(userId);
-        return ResponseEntity.ok(snapShotDTO);
+    @GetMapping
+    public ApiResponse<SnapShotDTO> snapShot(@AuthenticationPrincipal User user){
+        SnapShotDTO snapShotDTO = snapShotService.getRecentSnapShot(user.getUserId());
+        return ApiResponse.onSuccess(snapShotDTO);
     }
 }

--- a/src/main/java/com/hufs/algoing/submitting/controller/SubmittingController.java
+++ b/src/main/java/com/hufs/algoing/submitting/controller/SubmittingController.java
@@ -1,5 +1,6 @@
 package com.hufs.algoing.submitting.controller;
 
+import com.hufs.algoing.global.code.ApiResponse;
 import com.hufs.algoing.problem.entity.ProblemStatus;
 import com.hufs.algoing.submitting.service.SubmittingService;
 import com.hufs.algoing.user.entity.User;
@@ -10,15 +11,15 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/submit/")
+@RequestMapping("/api/submit/")
 public class SubmittingController {
 
     private final SubmittingService submittingService;
 
     @PostMapping("/{problemId}")
-    public ProblemStatus submit(@PathVariable Long problemId, @RequestBody String code, @RequestParam String language, @AuthenticationPrincipal User p) throws InterruptedException {
+    public ApiResponse<ProblemStatus> submit(@PathVariable Long problemId, @RequestBody String code, @RequestParam String language, @AuthenticationPrincipal User p) throws InterruptedException {
 //        String handle = p.getHandle();
-        return submittingService.submit(problemId, code, language, p);
+        return ApiResponse.onSuccess(submittingService.submit(problemId, code, language, p));
     }
 
 

--- a/src/main/java/com/hufs/algoing/user/controller/UserController.java
+++ b/src/main/java/com/hufs/algoing/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.hufs.algoing.user.controller;
 
+import com.hufs.algoing.global.code.ApiResponse;
 import com.hufs.algoing.solvedac.dto.SolvedAcProfileDTO;
 import com.hufs.algoing.solvedac.service.SolvedAcService;
 import com.hufs.algoing.user.service.UserService;
@@ -15,15 +16,15 @@ public class UserController {
     private SolvedAcService solvedAcService;
 
     @GetMapping("/{handle}")
-    public String getUser(@PathVariable String handle) {
+    public ApiResponse<String> getUser(@PathVariable String handle) {
         //임시
         SolvedAcProfileDTO profile = solvedAcService.getSolvedAcProfile(handle);
-        return profile.getBio() + " " + profile.getTier() + " " + profile.getSolvedCount() + " " + profile.getProfileImageUrl();
+        return ApiResponse.onSuccess(profile.getBio() + " " + profile.getTier() + " " + profile.getSolvedCount() + " " + profile.getProfileImageUrl());
     }
 
     @PutMapping("/{handle}")
-    public String updateUser(@PathVariable String handle) {
+    public ApiResponse<String> updateUser(@PathVariable String handle) {
         userService.updateUserData(handle);
-        return "User data updated successfully";
+        return ApiResponse.onSuccess("User data updated successfully");
     }
 }

--- a/src/main/java/com/hufs/algoing/user/controller/UserInfoController.java
+++ b/src/main/java/com/hufs/algoing/user/controller/UserInfoController.java
@@ -1,5 +1,6 @@
 package com.hufs.algoing.user.controller;
 
+import com.hufs.algoing.global.code.ApiResponse;
 import com.hufs.algoing.problem.dto.ZandiDTO;
 import com.hufs.algoing.user.dto.UserInfoDTO;
 import com.hufs.algoing.user.entity.User;
@@ -22,7 +23,7 @@ public class UserInfoController {
     }
 
     @GetMapping
-    public ResponseEntity<UserInfoDTO> getUserInfo(@AuthenticationPrincipal User p){
+    public ApiResponse<UserInfoDTO> getUserInfo(@AuthenticationPrincipal User p){
         UserInfoDTO userInfoDTO = new UserInfoDTO();
         userInfoDTO.setUserId(p.getUserId());
         userInfoDTO.setHandle(p.getHandle());
@@ -35,14 +36,14 @@ public class UserInfoController {
         userInfoDTO.setUserPoint(p.getUserPoint());
         userInfoDTO.setCreatedAt(p.getCreatedAt());
 
-        return ResponseEntity.ok(userInfoDTO);
+        return ApiResponse.onSuccess(userInfoDTO);
     }
 
     @GetMapping("/zandi")
-    public ResponseEntity<List<ZandiDTO>> getUserZandi(
+    public ApiResponse<List<ZandiDTO>> getUserZandi(
             @AuthenticationPrincipal User p){
         List<ZandiDTO> zandiDTOList = userService.getUserActivity(p);
-        return ResponseEntity.ok(zandiDTOList);
+        return ApiResponse.onSuccess(zandiDTOList);
     }
 
 }

--- a/src/main/java/com/hufs/algoing/user/entity/User.java
+++ b/src/main/java/com/hufs/algoing/user/entity/User.java
@@ -110,4 +110,9 @@ public class User implements UserDetails {
                 '}';
     }
 
+    public void updatePoint(int point) {
+        this.userPoint = point;
+    }
+
+
 }

--- a/src/main/resources/instructions/analyzeInstructions.md
+++ b/src/main/resources/instructions/analyzeInstructions.md
@@ -1,8 +1,7 @@
 **Role**
 
 ---
-
-Your role is to extract progress information about a particular problem. Your first goal is to solve the problem in advance and save the relevant information so that when the user submits the code, you can use your information to review the code. It extracts readability tips, optimization techniques, redundancy tips, and key patterns of the problem. The second goal is to solve the problem in advance and quantify and return the difficulty of readability, optimization, and redundancy of the problem out of 0 to 30. Based on this, I will proceed with customized recommendations. Your response must be in JSON format.
+Your role is to extract progress information about a particular problem. Your first goal is to analyze the problem in advance and store relevant information to review user-submitted code. You will extract readability tips, optimization techniques, redundancy tips, and key problem patterns. Your second goal is to evaluate and quantify the problem's difficulty (on a scale of 0-30) across three dimensions: readability, optimization, and redundancy. This evaluation will inform customized recommendations. The third goal is to provide three hints of the problem. All responses must be in JSON format.
 
 **Data Overview**
 
@@ -43,27 +42,34 @@ Data 3: Time limit, memory limit
 
 **Pre-Decision Analysis:**
 
-1. **Understanding the issue**
+1. Understanding the issue
 - The problem description is analyzed to summarize the core concepts and requirements.
-- Identify the type of problem (e.g., DP, Grindy, Graph, etc.).
-2. **Check input and output conditions**
+- Identify the type of problem (ex. DP, Gridy, Graph, etc.).
+2. Check input and output conditions
 - Analyze the range and format of the input.
 - Check what conditions the output value must satisfy.
-3. **Confirmation of constraints**
+3. Confirmation of constraints
 - Analyze time limits and memory limits.
 - The time complexity of the algorithm is predicted by considering the constraint conditions.
 
 **Decision Making:**
 
-4. **Select appropriate algorithms**
+4. Select appropriate algorithms
 - Select the appropriate algorithm for the type of problem.
 - Considering optimal time complexity, the solution strategy is determined.
-5. **Problem resolution and code writing**
+5. Problem resolution and code writing
 - Write and execute code to solve the problem.
 - Apply various test cases to check if the code is operating normally.
-6. **Code analysis and data storage**
+6. Code analysis and data storage
 - It analyzes the readability, optimization, and redundancy of the written code.
 - Save the analyzed content in JSON format.
+7. Analysis and generation of hints
+- Provides a step-by-step clue for the user to solve the problem.
+- Each hint gradually provides more information, but does not directly include the correct answer.
+- Please create a three-step hint as below:
+  Hint 1: Key types or classifications of problems (ex. Graph navigation, sorting, stacking, etc.)
+  Hint 2: Suggest algorithmic strategies, data structures, and approaches to use
+  Hint 3: Frequent mistakes, boundary conditions, implementation key flows
 
 **Considerations**
 
@@ -71,9 +77,11 @@ Data 3: Time limit, memory limit
 - Did you minimize unnecessary iterations?
 - Aren't the same code duplicated in multiple locations?
 - Is it easy to understand the code?
+- Please provide a JSON object in the following format:
+- The fields hint1, hint2, and hint3 must be written in Korean.
+- The fields readTip, optTip, dupTip and pattern must be written in English.
 
 **Example Instruction for Making a Decision (JSON format)**
-- Be sure to provide JSON with only the following format as a response.
 ---
 ```json
 {
@@ -83,6 +91,9 @@ Data 3: Time limit, memory limit
     "readTip": "Make the variable name more meaningful (ex: base, number)",
     "optTip": "You can use Integrer.parseInt() without repetition statements",
     "dupTip": "You can cache values to avoid duplicate operations",
-    "pattern": "Base Conversion"
+    "pattern": "Base Conversion",
+    "hint1": "스택을 사용하는 문자열 탐색 문제입니다.",
+    "hint2": "여는 괄호는 스택에 넣고, 닫는 괄호가 나올 때는 스택에서 빼며 비교하세요.",
+    "hint3": "스택이 비었는데 닫는 괄호가 나오면 틀린 경우입니다. 마지막에 스택이 비어 있어야 합니다."
 }
 ```


### PR DESCRIPTION
close #26 

- API 응답 형식을 `ApiResponse` 클래스를 통해 통일했습니다.
- 에러 핸들링 로직을 적용했습니다.
- 문제 힌트를 제공하는 힌트 API를 구현했습니다.
- 컨트롤러 경로에 /api 접두사를 추가했습니다.

컨트롤러 부분 응답 포맷 통일 및 API 경로 수정 확인 부탁드립니다!