### PR TITLE
[feat-39] 문제 로깅 구현하기

### DIFF
--- a/src/main/java/com/hufs/algoing/global/code/ErrorStatus.java
+++ b/src/main/java/com/hufs/algoing/global/code/ErrorStatus.java
@@ -14,7 +14,8 @@ public enum ErrorStatus implements BaseErrorCode{
     SNAPSHOT_NOT_FOUND(HttpStatus.BAD_REQUEST,"SNAPSHOT4001","해당 유저의 스냅샷이 없습니다."),
     PROBLEM_NOT_FOUND(HttpStatus.BAD_REQUEST, "PROBLEM4001","해당하는 문제가 없습니다." ),
     BOJ_ID_EXISTS(HttpStatus.BAD_REQUEST, "USER4002", "이미 존재하는 BOJ ID입니다."),
-    BOJ_ID_NOT_EXISTS(HttpStatus.BAD_REQUEST, "USER4003", "존재하지 않는 BOJ ID입니다.");
+    BOJ_ID_NOT_EXISTS(HttpStatus.BAD_REQUEST, "USER4003", "존재하지 않는 BOJ ID입니다."),
+    RECOMMENDATION_LOG_NOT_FOUND(HttpStatus.BAD_REQUEST, "LOG4001", "존재하지 않는 추천 로그입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/hufs/algoing/global/exception/custom/RecommendationLogNotFoundException.java
+++ b/src/main/java/com/hufs/algoing/global/exception/custom/RecommendationLogNotFoundException.java
@@ -1,0 +1,9 @@
+package com.hufs.algoing.global.exception.custom;
+
+import com.hufs.algoing.global.code.BaseErrorCode;
+import com.hufs.algoing.global.exception.GeneralException;
+
+public class RecommendationLogNotFoundException extends GeneralException {
+    public RecommendationLogNotFoundException(BaseErrorCode errorCode) {super(errorCode);
+    }
+}

--- a/src/main/java/com/hufs/algoing/problem/entity/SubmittedProblem.java
+++ b/src/main/java/com/hufs/algoing/problem/entity/SubmittedProblem.java
@@ -46,6 +46,8 @@ public class SubmittedProblem {
     @Column
     private LocalDate submittedDate;
 
+    private String recommendationSessionId;
+
     // submittedDate는 submittedAt에서 자동 생성
     @PrePersist
     public void prePersist() {
@@ -56,7 +58,7 @@ public class SubmittedProblem {
     public SubmittedProblem(
             User userId, Problem problemId,
             String answer, LocalDateTime submittedAt, LocalDate submittedDate, String language,
-            ProblemStatus status) {
+            ProblemStatus status, String recommendationSessionId) {
         this.userId = userId;
         this.problemId = problemId;
         this.answer = answer;
@@ -64,6 +66,7 @@ public class SubmittedProblem {
         this.language = language;
         this.status = status;
         this.submittedDate = LocalDate.now();
+        this.recommendationSessionId = recommendationSessionId;
     }
 
     //Solved일때만 true

--- a/src/main/java/com/hufs/algoing/recommendation/controller/RecommendController.java
+++ b/src/main/java/com/hufs/algoing/recommendation/controller/RecommendController.java
@@ -1,6 +1,7 @@
 package com.hufs.algoing.recommendation.controller;
 
 import com.hufs.algoing.global.code.ApiResponse;
+import com.hufs.algoing.recommendation.dto.CombinedRecommendationsDTO;
 import com.hufs.algoing.recommendation.dto.DailyRecommendDTO;
 import com.hufs.algoing.recommendation.dto.IncProblemRecommendDTO;
 import com.hufs.algoing.recommendation.dto.WeaknessRecommendDTO;
@@ -9,12 +10,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @Tag(name = "Recommend API", description = "추천 API")
 @RestController
@@ -24,33 +23,57 @@ public class RecommendController {
 
     private final RecommendService recommendService;
 
-    @Operation(summary = "userId", description = "요청 받은 사용자의 티어와 선호 문제 유형을 기반으로 문제를 추천합니다.")
-    @Parameter(name = "long", description = "추천 받을 사용자 id")
+    @Operation(summary = "일간 추천", description = "요청 받은 사용자의 티어와 선호 문제 유형을 기반으로 문제를 추천합니다.")
+    @Parameter(name = "userId", description = "추천 받을 사용자 id")
     @GetMapping("daily/{userId}")
     public ApiResponse<List<DailyRecommendDTO>> getDailyRecommendations(@PathVariable Long userId) {
+        // 단일 추천
+        String recommendationSessionId = UUID.randomUUID().toString();
         // 서비스 호출하여 추천 문제 목록 가져오기
-        List<DailyRecommendDTO> recommendations = recommendService.getDailyRecommendations(userId);
+        List<DailyRecommendDTO> recommendations = recommendService.getDailyRecommendations(userId, recommendationSessionId);
         recommendations.forEach(recommendation -> System.out.println(recommendation.toString()));
 
         return ApiResponse.onSuccess(recommendations);
     }
 
-    @Operation(summary = "userId", description = "요청 받은 사용자의 약점을 기반으로 문제를 추천합니다.")
-    @Parameter(name = "long", description = "추천 받을 사용자 id")
+    @Operation(summary = "약점 보완 추천", description = "요청 받은 사용자의 약점을 기반으로 문제를 추천합니다.")
+    @Parameter(name = "userId", description = "추천 받을 사용자 id")
     @GetMapping("weakness/{userId}")
     public ApiResponse<List<WeaknessRecommendDTO>> getWeaknessRecommendations(@PathVariable Long userId){
-        List<WeaknessRecommendDTO> recommendations = recommendService.getWeaknessRecommendations(userId);
+        // 단일 추천
+        String recommendationSessionId = UUID.randomUUID().toString();
+        List<WeaknessRecommendDTO> recommendations = recommendService.getWeaknessRecommendations(userId, recommendationSessionId);
         recommendations.forEach(recommendation -> System.out.println(recommendation));
         return ApiResponse.onSuccess(recommendations);
     }
 
-    @Operation(summary = "userId", description = "요청 받은 사용자의 많이 틀린 문제 유형 기반으로 문제를 추천합니다.")
-    @Parameter(name = "long", description = "추천 받을 사용자 id")
+    @Operation(summary = "틀린 문제 유형 기반 추천", description = "요청 받은 사용자의 많이 틀린 문제 유형 기반으로 문제를 추천합니다.")
+    @Parameter(name = "userId", description = "추천 받을 사용자 id")
     @GetMapping("incproblem/{userId}")
     public ApiResponse<List<IncProblemRecommendDTO>> getIncProblemRecommendation(@PathVariable Long userId) {
-        List<IncProblemRecommendDTO> recommendations = recommendService.getIncProblemRecommendation(userId);
+        // 단일 추천
+        String recommendationSessionId = UUID.randomUUID().toString();
+        List<IncProblemRecommendDTO> recommendations = recommendService.getIncProblemRecommendation(userId, recommendationSessionId);
         recommendations.forEach(recommendation -> System.out.println(recommendation.toString()));
 
         return ApiResponse.onSuccess(recommendations);
+    }
+
+    @Operation(summary = "모든 추천 가져오기", description = "요청 받은 사용자를 위한 모든 추천 유형(Daily, Weakness, IncProblem)을 한 번에 추천합니다.")
+    @Parameter(name = "userId", description = "추천 받을 사용자 id", example = "1")
+    @GetMapping("/all/{userId}")
+    public ApiResponse<CombinedRecommendationsDTO> getAllRecommendationsForUser(@PathVariable Long userId) {
+        CombinedRecommendationsDTO response = recommendService.getAllRecommendations(userId);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @Operation(summary = "추천 문제 클릭 기록", description = "사용자가 추천된 문제를 클릭했음을 기록합니다.")
+    @Parameter(name = "userId", description = "클릭한 사용자 ID", example = "1")
+    @Parameter(name = "problemId", description = "클릭된 문제 ID", example = "1000")
+    @Parameter(name = "sessionId", description = "추천 세션 ID (클릭된 문제가 속한 세션)", example = "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+    @PostMapping("/click")
+    public ApiResponse<String> recordClick(@RequestParam Long userId, @RequestParam Long problemId, @RequestParam String sessionId) {
+        recommendService.recordRecommendationClick(userId, problemId, sessionId);
+        return ApiResponse.onSuccess("클릭을 성공적으로 기록했습니다");
     }
 }

--- a/src/main/java/com/hufs/algoing/recommendation/dto/CombinedRecommendationsDTO.java
+++ b/src/main/java/com/hufs/algoing/recommendation/dto/CombinedRecommendationsDTO.java
@@ -1,0 +1,17 @@
+package com.hufs.algoing.recommendation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CombinedRecommendationsDTO {
+    private String recommendationSessionId; // 추천 받은 페이지 세션 ID
+    private List<DailyRecommendDTO> dailyRecommendations;
+    private List<WeaknessRecommendDTO> weaknessRecommendations;
+    private List<IncProblemRecommendDTO> incProblemRecommendations;
+}

--- a/src/main/java/com/hufs/algoing/recommendation/log/RecommendationLog.java
+++ b/src/main/java/com/hufs/algoing/recommendation/log/RecommendationLog.java
@@ -1,0 +1,68 @@
+package com.hufs.algoing.recommendation.log;
+
+import com.hufs.algoing.problem.entity.Problem;
+import com.hufs.algoing.user.entity.User;
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "recommendation_log")
+public class RecommendationLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String recommendationSessionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user; // 추천을 받은 사용자
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "problem_id", nullable = false)
+    private Problem problem; // 추천된 문제
+
+    @Column(name="recommendation_type", nullable = false)
+    private String recommendationType; // Daily, Weakness, IncProblem
+
+    @Column(name = "recommendation_score")
+    private Double recommendationScore; // 추천 당시 점수
+
+    @Column(name="recommended_at", nullable = false)
+    private LocalDateTime recommendedAt; // 추천 생성 시각
+
+    @Column(name="clicked_at")
+    private LocalDateTime clickedAt; // 사용자가 이 추천을 클릭한 시각
+
+    @Column(name="is_clicked", nullable = false)
+    private boolean isClicked; // 클릭 여부
+
+    @Builder
+    public RecommendationLog(String recommendationSessionId, User user, Problem problem,
+                             String recommendationType, Double recommendationScore) {
+        this.recommendationSessionId = recommendationSessionId;
+        this.user = user;
+        this.problem = problem;
+        this.recommendationType = recommendationType;
+        this.recommendationScore = recommendationScore;
+        this.recommendedAt = LocalDateTime.now();
+        this.isClicked = false;
+    }
+
+    // 추천 클릭 시 호출
+    public void markAsClicked() {
+        this.isClicked = true;
+        this.clickedAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/com/hufs/algoing/recommendation/log/RecommendationLogRepository.java
+++ b/src/main/java/com/hufs/algoing/recommendation/log/RecommendationLogRepository.java
@@ -1,0 +1,21 @@
+package com.hufs.algoing.recommendation.log;
+
+import com.hufs.algoing.problem.entity.Problem;
+import com.hufs.algoing.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+import java.util.Optional;
+import java.time.LocalDateTime;
+
+@Repository
+public interface RecommendationLogRepository extends JpaRepository<RecommendationLog, Long> {
+
+    // 클릭 이벤트 처리를 위해 특정 로그를 찾는 메서드
+    // 가장 최근 추천된 특정 문제의 로그를 찾는 경우
+    Optional<RecommendationLog> findTopByUserUserIdAndProblemProblemIdAndRecommendationSessionIdOrderByRecommendedAtDesc(
+            Long userId, Long problemId, String recommendationSessionId);
+
+
+}

--- a/src/main/java/com/hufs/algoing/recommendation/service/RecommendService.java
+++ b/src/main/java/com/hufs/algoing/recommendation/service/RecommendService.java
@@ -3,6 +3,8 @@ package com.hufs.algoing.recommendation.service;
 import com.hufs.algoing.aisolved.entity.AISolved;
 import com.hufs.algoing.aisolved.repository.AISolvedRepository;
 import com.hufs.algoing.global.code.ErrorStatus;
+import com.hufs.algoing.global.exception.custom.ProblemNotFoundException;
+import com.hufs.algoing.global.exception.custom.RecommendationLogNotFoundException;
 import com.hufs.algoing.global.exception.custom.UserNotFoundException;
 import com.hufs.algoing.problem.entity.Problem;
 import com.hufs.algoing.problem.entity.SubmittedProblem;
@@ -11,20 +13,28 @@ import com.hufs.algoing.problem.repository.SubmittedProblemRepository;
 import com.hufs.algoing.recommendation.algorithm.DailyRecommendAlgorithm;
 import com.hufs.algoing.recommendation.algorithm.IncProblemRecommendAlgorithm;
 import com.hufs.algoing.recommendation.algorithm.WeaknessRecommendAlgorithm;
+import com.hufs.algoing.recommendation.dto.CombinedRecommendationsDTO;
 import com.hufs.algoing.recommendation.dto.DailyRecommendDTO;
 import com.hufs.algoing.recommendation.dto.IncProblemRecommendDTO;
 import com.hufs.algoing.recommendation.dto.WeaknessRecommendDTO;
+import com.hufs.algoing.recommendation.log.RecommendationLog;
+import com.hufs.algoing.recommendation.log.RecommendationLogRepository;
 import com.hufs.algoing.review.entity.Review;
 import com.hufs.algoing.review.repository.ReviewRepository;
 import com.hufs.algoing.user.entity.User;
 import com.hufs.algoing.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class RecommendService {
 
     private final ProblemRepository problemRepository;
@@ -33,8 +43,9 @@ public class RecommendService {
     private final ReviewRepository reviewRepository;
     private final AISolvedRepository aisolvedRepository;
     private final IncProblemRecommendAlgorithm incProblemRecommendAlgorithm;
+    private final RecommendationLogRepository recommendationLogRepository;
 
-    public List<DailyRecommendDTO> getDailyRecommendations(Long userId) {
+    public List<DailyRecommendDTO> getDailyRecommendations(Long userId, String recommendationSessionId) {
 
         // 유저 정보 가져오기
         User user = userRepository.findById(userId)
@@ -51,10 +62,24 @@ public class RecommendService {
 
         for (DailyRecommendDTO dto : recommendations) {
         }
+
+        // 로깅
+        List<RecommendationLog> logs = recommendations.stream()
+                .map(dto -> RecommendationLog.builder()
+                        .recommendationSessionId(recommendationSessionId)
+                        .user(user)
+                        .problem(problemRepository.findById(dto.getProblemId())
+                                .orElseThrow(() -> new ProblemNotFoundException(ErrorStatus.PROBLEM_NOT_FOUND)))
+                        .recommendationType("Daily")
+                        .recommendationScore(dto.getScore()) // 추천 점수
+                        .build())
+                .collect(Collectors.toList());
+        recommendationLogRepository.saveAll(logs);
+
         return recommendations;
     }
 
-    public List<WeaknessRecommendDTO> getWeaknessRecommendations(Long userId) {
+    public List<WeaknessRecommendDTO> getWeaknessRecommendations(Long userId, String recommendationSessionId) {
 
         //유저 정보 가져오기
         User user = userRepository.findById(userId)
@@ -77,19 +102,74 @@ public class RecommendService {
         List<WeaknessRecommendDTO> recommendations = WeaknessRecommendAlgorithm.recommend(user, allReviews, allAiSolved, allSolvedProblems, allProblems);
         for (WeaknessRecommendDTO dto : recommendations) {
         }
+
+        // 로깅
+        List<RecommendationLog> logs = recommendations.stream()
+                .map(dto -> RecommendationLog.builder()
+                        .recommendationSessionId(recommendationSessionId)
+                        .user(user)
+                        .problem(problemRepository.findById(dto.getProblemId())
+                                .orElseThrow(() -> new ProblemNotFoundException(ErrorStatus.PROBLEM_NOT_FOUND)))
+                        .recommendationType("Weakness")
+                        .recommendationScore(dto.getFinalScore())
+                        .build())
+                .collect(Collectors.toList());
+        recommendationLogRepository.saveAll(logs);
         return recommendations;
 
 
     }
 
-    public List<IncProblemRecommendDTO> getIncProblemRecommendation(Long userId) {
+    public List<IncProblemRecommendDTO> getIncProblemRecommendation(Long userId, String recommendationSessionId) {
 
         //유저 정보 가져오기
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException(ErrorStatus.USER_NOT_FOUND));
         System.out.println(user);
 
-        return incProblemRecommendAlgorithm.recommend(user);
+        List<IncProblemRecommendDTO> recommendations = incProblemRecommendAlgorithm.recommend(user);
+
+        // 로깅
+        List<RecommendationLog> logs = recommendations.stream()
+                .map(dto -> RecommendationLog.builder()
+                        .recommendationSessionId(recommendationSessionId)
+                        .user(user)
+                        .problem(problemRepository.findById(dto.getProblemId())
+                                .orElseThrow(() -> new ProblemNotFoundException(ErrorStatus.PROBLEM_NOT_FOUND)))
+                        .recommendationType("IncProblem")
+                        .recommendationScore(null)
+                        .build())
+                .collect(Collectors.toList());
+        recommendationLogRepository.saveAll(logs);
+
+        return recommendations;
 
     }
+
+    @Transactional
+    public CombinedRecommendationsDTO getAllRecommendations(Long userId) {
+
+        String recommendationSessionId = UUID.randomUUID().toString();
+
+        List<DailyRecommendDTO> dailyRecs = getDailyRecommendations(userId, recommendationSessionId);
+        List<WeaknessRecommendDTO> weaknessRecs = getWeaknessRecommendations(userId, recommendationSessionId);
+        List<IncProblemRecommendDTO> incProblemRecs = getIncProblemRecommendation(userId, recommendationSessionId);
+
+        return new CombinedRecommendationsDTO(recommendationSessionId, dailyRecs, weaknessRecs, incProblemRecs);
+    }
+
+
+    @Transactional
+    public void recordRecommendationClick(Long userId, Long problemId, String recommendationSessionId) {
+
+        RecommendationLog log = recommendationLogRepository.findTopByUserUserIdAndProblemProblemIdAndRecommendationSessionIdOrderByRecommendedAtDesc(
+                        userId, problemId, recommendationSessionId)
+                .orElseThrow(() -> new RecommendationLogNotFoundException(ErrorStatus.RECOMMENDATION_LOG_NOT_FOUND));
+
+        if (!log.isClicked()) {
+            log.markAsClicked();
+            recommendationLogRepository.save(log);
+        }
+    }
+
 }

--- a/src/main/java/com/hufs/algoing/submit/controller/SubmitController.java
+++ b/src/main/java/com/hufs/algoing/submit/controller/SubmitController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/submit")
+@RequestMapping("/api/submit")
 @Slf4j
 @Tag(name = "Submit API", description = "문제 제출 및 채점 API")
 public class SubmitController {

--- a/src/main/java/com/hufs/algoing/submit/controller/SubmitController.java
+++ b/src/main/java/com/hufs/algoing/submit/controller/SubmitController.java
@@ -4,6 +4,8 @@ import com.hufs.algoing.global.code.ApiResponse;
 import com.hufs.algoing.submit.dto.RecaptchaResponseDTO;
 import com.hufs.algoing.submit.dto.SubmitRequestDTO;
 import com.hufs.algoing.submit.service.SubmitService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,20 +13,19 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-//
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/submit")
 @Slf4j
+@Tag(name = "Submit API", description = "문제 제출 및 채점 API")
 public class SubmitController {
     private final SubmitService submitService;
 
-
-    // 캡차 해결 + 자동 제출
-
+    @Operation(summary = "문제 코드 제출 및 채점", description = "사용자가 제출한 코드와 정보를 기반으로 문제를 채점합니다.")
     @PostMapping
     public ApiResponse<RecaptchaResponseDTO> solveCaptcha(@RequestBody SubmitRequestDTO dto) throws Exception {
         RecaptchaResponseDTO result = submitService.solveAndJudge(dto);
+
         return ApiResponse.onSuccess(result);
     }
 

--- a/src/main/java/com/hufs/algoing/submit/dto/SubmitRequestDTO.java
+++ b/src/main/java/com/hufs/algoing/submit/dto/SubmitRequestDTO.java
@@ -1,14 +1,21 @@
 package com.hufs.algoing.submit.dto;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class SubmitRequestDTO {
+    @Schema(description = "제출 사용자 ID", example = "1")
     private Long userId;
+    @Schema(description = "제출 문제 번호", example = "1000")
     private Long problemNum;
+    @Schema(description = "제출 코드 언어 ('Java 11', 'Python 3', 'C++17')")
     private String language;
+    @Schema(description = "제출 코드 본문", example = "import java.util.*;\n\nclass Solution {\n    public int solution(int a, int b) {\n        return a + b;\n    }\n}")
     private String code;
+    @Schema(description = "이 제출이 특정 추천 세션을 통해 발생했다면 해당 세션 ID (UUID)", example = "a1b2c3d4-e5f6-7890-abcd-ef1234567890", nullable = true)
+    private String recommendationSessionId;
 }

--- a/src/main/java/com/hufs/algoing/submit/service/SubmitService.java
+++ b/src/main/java/com/hufs/algoing/submit/service/SubmitService.java
@@ -8,6 +8,7 @@ import com.hufs.algoing.problem.entity.ProblemStatus;
 import com.hufs.algoing.problem.entity.SubmittedProblem;
 import com.hufs.algoing.problem.repository.ProblemRepository;
 import com.hufs.algoing.problem.repository.SubmittedProblemRepository;
+import com.hufs.algoing.recommendation.service.RecommendService;
 import com.hufs.algoing.submit.dto.RecaptchaRequestDTO;
 import com.hufs.algoing.submit.dto.RecaptchaResponseDTO;
 import com.hufs.algoing.submit.dto.SubmitRequestDTO;
@@ -116,6 +117,7 @@ public class SubmitService {
                 .answer(dto.getCode())
                 .language(dto.getLanguage())
                 .status(status)
+                .recommendationSessionId(dto.getRecommendationSessionId())
                 .build();
 
         // 제출 문제 저장

--- a/src/main/java/com/hufs/algoing/user/controller/UserAuthController.java
+++ b/src/main/java/com/hufs/algoing/user/controller/UserAuthController.java
@@ -12,11 +12,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "User Auth API", description = "유저 로그인 API")
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api")
 public class UserAuthController {
 
     private final UserService userService;


### PR DESCRIPTION
- 추천 항목 간 동일한 추천 세션(recommendationSessionId)을 기준으로 관리할 수 있도록 기존의 분리된 API(daily, weakness 등)를 하나의 통합된 엔드포인트로 변경했습니다.
- 사용자의 추천된 문제 클릭을 기록하는 API를 구현했습니다.